### PR TITLE
parse tags without a v prefix correctly

### DIFF
--- a/packager/action.yaml
+++ b/packager/action.yaml
@@ -54,7 +54,10 @@ runs:
         then
           echo "Parsing tag from: ${{ github.ref_name }}"
           _tag="${{ github.ref_name }}"
-          _version="${_tag:1}" # drop the v
+          _version="${_tag}"
+          if [[ $_version == v* ]]
+              _version="${_tag:1}"
+          fi
         fi
 
         if [ -z $_version ]


### PR DESCRIPTION
Signed-off-by: R.I.Pienaar <rip@devco.net>