### PR TITLE
(misc) update staticcheck to latest

### DIFF
--- a/lint_and_test/go/action.yaml
+++ b/lint_and_test/go/action.yaml
@@ -42,7 +42,7 @@ runs:
     - name: Static Check
       shell: bash
       run: |
-        go install honnef.co/go/tools/cmd/staticcheck@2022.1
+        go install honnef.co/go/tools/cmd/staticcheck@latest
         staticcheck $(go list ./...)
 
     - name: Go Test


### PR DESCRIPTION
We used to pin staticcheck for go1.18 weirdness but now that's fixed and the version we pinned to had other bugs that prevented us from updating uber atomic

So back to using latest which should be good
for 1.18+

Signed-off-by: R.I.Pienaar <rip@devco.net>